### PR TITLE
added the ability to use emojis in chat conversations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
   <dependencies>
 
     <dependency>
+      <groupId>com.vdurmont</groupId>
+      <artifactId>emoji-java</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.vladsch.flexmark</groupId>
       <artifactId>flexmark-all</artifactId>
       <version>0.32.24</version>

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -44,6 +44,9 @@ import com.vladsch.flexmark.util.options.MutableDataSet;
 
 import java.util.Arrays;
 
+// import for emoji parser
+import com.vdurmont.emoji.EmojiParser;
+
 /** Servlet class responsible for the chat page. */
 public class ChatServlet extends HttpServlet {
 
@@ -196,6 +199,10 @@ public class ChatServlet extends HttpServlet {
 
     // this removes any style / script / html (other than allowed tags) from the message content
     String cleanedMessageContent = Jsoup.clean(markdownContent, "", allowedTags, settings);
+
+    //this parses emojis to unicode and html
+    cleanedMessageContent = EmojiParser.parseToUnicode(cleanedMessageContent);
+    cleanedMessageContent = EmojiParser.parseToHtmlDecimal(cleanedMessageContent);
 
     Message message =
         new Message(

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -203,16 +203,16 @@ public class ChatServletTest {
 
     Mockito.when(mockRequest.getParameter("message"))
         .thenReturn("Contains <ins>underline</ins>, <del>strike</del>, <strong>bold</strong>,"
-        + " <em>italics</em>, <sub>subscript</sub>, <sup>superscript</sup>, and"
+        + " <em>italics</em>, <sub>subscript</sub>, <sup>superscript</sup>, :grinning:, and"
         + " <script>JavaScript</script> content.");
     chatServlet.doPost(mockRequest, mockResponse);
 
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
-    // this insert tag addition tests if whitelist is working
+    // these html tags and emoji addition tests if whitelist and parsing is working
     Assert.assertEquals(
         "Contains <ins>underline</ins>, <del>strike</del>, <strong>bold</strong>, <em>italics</em>,"
-        + " <sub>subscript</sub>, <sup>superscript</sup>, and  content.",
+        + " <sub>subscript</sub>, <sup>superscript</sup>, &#128512;, and  content.",
         messageArgumentCaptor.getValue().getContent());
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }


### PR DESCRIPTION
__you can now use emojis in our chat!__ I updated pom.xml to include the java emoji library, ChatServlet.java to import parser and parse emojis, and added on to ChatServletTest.java to make sure emojis display.

**examples**
`:turtle:` becomes 🐢 
`:cat:` becomes 🐱 

aliases with all corresponding emojis: [https://github.com/vdurmont/emoji-java#available-emojis](https://github.com/vdurmont/emoji-java#available-emojis)

this is how the emojis look in the app: [http://bex-imhere.appspot.com/chat/sphynx](http://bex-imhere.appspot.com/chat/sphynx)

